### PR TITLE
Add possibility to pass variable

### DIFF
--- a/thumbnail.rb
+++ b/thumbnail.rb
@@ -32,14 +32,14 @@ class Jekyll::Thumbnail < Liquid::Tag
   def render(context)
     if @source
 
-      if /\{\{([\w\-]+)\}\}/ =~ @source
-        raise ArgumentError.new("No variable #{$1} was found in thumbnail tag") if context[$1].nil?
-        @source = context[$1]
-      end
-
       # parking
       source = @source
       dimensions = @dimensions
+
+      if /\{\{([\w\-]+)\}\}/ =~ @source
+        raise ArgumentError.new("No variable #{$1} was found in thumbnail tag") if context[$1].nil?
+        source = context[$1]
+      end
 
       source_path = "./source#{source}"
       raise "#{source} is not readable" unless File.readable?(source_path)

--- a/thumbnail.rb
+++ b/thumbnail.rb
@@ -32,6 +32,11 @@ class Jekyll::Thumbnail < Liquid::Tag
   def render(context)
     if @source
 
+      if /\{\{([\w\-]+)\}\}/ =~ @source
+        raise ArgumentError.new("No variable #{$1} was found in thumbnail tag") if context[$1].nil?
+        @source = context[$1]
+      end
+
       # parking
       source = @source
       dimensions = @dimensions


### PR DESCRIPTION
This commit makes possible to pass paths to files as variables. E.g.:

```
{% thumbnail {{path}} 50x50< %}
```

Commit was based on:
https://github.com/maul-esel/jekyll/commit/a93795bcc06f7a9283602efc4e8ed3f0d37a5272
